### PR TITLE
:wrench: renovate : basculer sur le preset partagé UnPoilTefal/renovate-config

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -1,6 +1,6 @@
 {
   "$schema": "https://docs.renovatebot.com/renovate-schema.json",
   "extends": [
-    "config:recommended"
+    "github>UnPoilTefal/renovate-config"
   ]
 }


### PR DESCRIPTION
Alignement avec la convention des autres repos de l'org : `extends: ["config:recommended"]` → `extends: ["github>UnPoilTefal/renovate-config"]`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)